### PR TITLE
Fix the build on GHC 8.4

### DIFF
--- a/src/Data/OrdPSQ/Internal.hs
+++ b/src/Data/OrdPSQ/Internal.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE BangPatterns        #-}
+{-# LANGUAGE CPP                 #-}
 {-# LANGUAGE DeriveFoldable      #-}
 {-# LANGUAGE DeriveFunctor       #-}
 {-# LANGUAGE DeriveTraversable   #-}
@@ -74,7 +75,11 @@ import           Data.Foldable    (Foldable (foldr))
 import qualified Data.List        as List
 import           Data.Maybe       (isJust)
 import           Data.Traversable
-import           Prelude          hiding (foldr, lookup, map, null)
+import           Prelude          hiding ( foldr, lookup, map, null
+#if MIN_VERSION_base(4,11,0)
+                                         , (<>)
+#endif
+                                         )
 
 --------------------------------------------------------------------------------
 -- Types


### PR DESCRIPTION
On `base-4.11` (GHC 8.4), the `Prelude` exports `(<>)` from the `Semigroup` class, which conflicts with a function of the same name in `Data.OrdPSQ.Internal`. This fixes the issue by hiding `(<>)` from the `Prelude` on sufficiently recent versions of `base`.