### PR TITLE
Relax QuickCheck upper bound and hide (<>) on 8.4

### DIFF
--- a/psqueues.cabal
+++ b/psqueues.cabal
@@ -142,7 +142,7 @@ Test-suite psqueues-tests
 
     Build-depends:
           HUnit                      >= 1.2 && < 1.7
-        , QuickCheck                 >= 2.7 && < 2.11
+        , QuickCheck                 >= 2.7 && < 2.12
         , test-framework             >= 0.8 && < 0.9
         , test-framework-hunit       >= 0.3 && < 0.4
         , test-framework-quickcheck2 >= 0.3 && < 0.4

--- a/src/Data/OrdPSQ/Internal.hs
+++ b/src/Data/OrdPSQ/Internal.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE BangPatterns        #-}
+{-# LANGUAGE CPP                 #-}
 {-# LANGUAGE DeriveFoldable      #-}
 {-# LANGUAGE DeriveFunctor       #-}
 {-# LANGUAGE DeriveTraversable   #-}
@@ -74,7 +75,11 @@ import           Data.Foldable    (Foldable (foldr))
 import qualified Data.List        as List
 import           Data.Maybe       (isJust)
 import           Data.Traversable
+#if MIN_VERSION_base(4,11,0)
+import           Prelude          hiding (foldr, lookup, map, null, (<>))
+#else
 import           Prelude          hiding (foldr, lookup, map, null)
+#endif
 
 --------------------------------------------------------------------------------
 -- Types


### PR DESCRIPTION
I tested that the build succeeds on 8.4 and that the tests still pass with QuickCheck-2.11.