### PR TITLE
Update hashable to include 1.4

### DIFF
--- a/psqueues.cabal
+++ b/psqueues.cabal
@@ -66,7 +66,7 @@ Library
     Build-depends:
           base     >= 4.2     && < 5
         , deepseq  >= 1.2     && < 1.5
-        , hashable >= 1.1.2.3 && < 1.4
+        , hashable >= 1.1.2.3 && < 1.5
 
     if impl(ghc>=6.10)
         Build-depends: ghc-prim


### PR DESCRIPTION
This PR updates the version bound for [`hashable`](https://hackage.haskell.org/package/hashable) to allow building with 1.4