### PR TITLE
Simplify Eq instance

### DIFF
--- a/src/Data/OrdPSQ/Internal.hs
+++ b/src/Data/OrdPSQ/Internal.hs
@@ -72,6 +72,7 @@ module Data.OrdPSQ.Internal
 
 import           Control.DeepSeq  (NFData (rnf))
 import           Data.Foldable    (Foldable (foldr))
+import           Data.Function    (on)
 import qualified Data.List        as List
 import           Data.Maybe       (isJust)
 import           Data.Traversable
@@ -106,12 +107,8 @@ instance (NFData k, NFData p, NFData v) => NFData (OrdPSQ k p v) where
     rnf (Winner e t m) = rnf e `seq` rnf m `seq` rnf t
 
 instance (Ord k, Ord p, Eq v) => Eq (OrdPSQ k p v) where
-    x == y = case (minView x, minView y) of
-        (Nothing              , Nothing                ) -> True
-        (Just (xk, xp, xv, x'), (Just (yk, yp, yv, y'))) ->
-            xk == yk && xp == yp && xv == yv && x' == y'
-        (Just _               , Nothing                ) -> False
-        (Nothing              , Just _                 ) -> False
+    (==) = (==) `on` minView
+    {-# INLINABLE (==) #-}
 
 type Size = Int
 


### PR DESCRIPTION
* Define ``(==) = (==) `on` minView``, which is completely equivalent to what was written before, but much shorter and clearer.

* Add an `INLINABLE` pragma to `(==)` to allow it to specialize. Previously, it did not get an unfolding.