### PR TITLE
Fix the fromList implementation for OrdPSQ

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,7 @@
 # CHANGELOG
+- ????
+    * Fix a bug in `fromList`. It previously used the *first* occurrence
+      of a duplicated key; it now uses the *last* occurrence, as documented.
 
 - 0.2.7.3 (2021-11-05)
     * Relax hashable, tasty and QuickCheck upper bounds

--- a/src/Data/OrdPSQ/Internal.hs
+++ b/src/Data/OrdPSQ/Internal.hs
@@ -71,7 +71,7 @@ module Data.OrdPSQ.Internal
     ) where
 
 import           Control.DeepSeq  (NFData (rnf))
-import           Data.Foldable    (Foldable (foldr))
+import           Data.Foldable    (Foldable (foldl'))
 import qualified Data.List        as List
 import           Data.Maybe       (isJust)
 import           Data.Traversable
@@ -290,7 +290,7 @@ alterMin f psq0 =
 -- last priority and value for the key is retained.
 {-# INLINABLE fromList #-}
 fromList :: (Ord k, Ord p) => [(k, p, v)] -> OrdPSQ k p v
-fromList = foldr (\(k, p, v) q -> insert k p v q) empty
+fromList = foldl' (\q (k, p, v) -> insert k p v q) empty
 
 -- | /O(n)/ Convert a queue to a list of (key, priority, value) tuples. The
 -- order of the list is not specified.

--- a/tests/Data/PSQ/Class/Tests.hs
+++ b/tests/Data/PSQ/Class/Tests.hs
@@ -178,9 +178,12 @@ test_fromList
     :: forall psq. (PSQ psq, TestKey (Key psq),
                     Eq (psq Int Char), Show (psq Int Char))
     => Tagged psq Assertion
-test_fromList = Tagged $
+test_fromList = Tagged $ do
     let ls = [(1, 0, 'A'), (2, 0, 'B'), (3, 0, 'C'), (4, 0, 'D')]
-    in (fromList ls :: psq Int Char) @?= fromList (reverse ls)
+      in (fromList ls :: psq Int Char) @?= fromList (reverse ls)
+    let qs = [(4, 0, 'D'), (1, 5, 'Q'), (2, 0, 'B'), (1, 0, 'A'), (3, 0, 'C'), (2, 5, 'Z')]
+        qs' = [(1, 0, 'A'), (2, 5, 'Z'), (3, 0, 'C'), (4, 0, 'D')]
+      in List.sort (toList (fromList qs :: psq Int Char)) @?= qs'
 
 test_foldr
     :: forall psq. (PSQ psq, TestKey (Key psq),


### PR DESCRIPTION
Make the `fromList` semantics match those claimed in the documentation.

Fixes #47