### PR TITLE
Fix OrdPSQ tree balancing logic. fixes #60

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ tags
 *.swp
 .cabal-sandbox
 cabal.sandbox.config
+dist-newstyle


### PR DESCRIPTION
The OrdPSQ tree balancing logic would never run on a node with
a leaf directly below it, even when the other child is deeply
nested. This appears to be the result of an attempt at optimizing
the code in the original Hinze paper, but missing this case.

This patch reverts the balancing logic to what is described in the
paper.

It additionally adds a check that the tree is balanced to the valid
predicate. Including that check without the fix results in the test
suite failing. The fix restore passing in the test suite.